### PR TITLE
因版本问题指定OpenAi的模型问题 

### DIFF
--- a/langchain/jupyter/model_io/output_parser.ipynb
+++ b/langchain/jupyter/model_io/output_parser.ipynb
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(temperature=0)"
+    "llm = OpenAI(temperature=0,model_name="gpt-3.5-turbo")"
    ]
   },
   {

--- a/langchain/jupyter/model_io/output_parser.ipynb
+++ b/langchain/jupyter/model_io/output_parser.ipynb
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(temperature=0,model_name="gpt-3.5-turbo")"
+    "llm = OpenAI(temperature=0,model_name='gpt-3.5-turbo')"
    ]
   },
   {


### PR DESCRIPTION
由于版本不同的原因，某些版本 model_name 默认为 gpt-3.5-turbo-instruct，导致一些黑魔法失效